### PR TITLE
Add psutil and audioop-lts to requirements

### DIFF
--- a/dist/requirements.txt
+++ b/dist/requirements.txt
@@ -15,4 +15,8 @@ xhtml2pdf
 beautifulsoup4
 lxml
 pydub
-
+psutil
+# pydub imports the stdlib audioop module, which PEP 594 removed in Python 3.13.
+# audioop-lts is the drop-in replacement, and it requires 3.13+, so it must stay
+# behind a marker or it breaks installs on the 3.10-3.12 range the README supports.
+audioop-lts; python_version >= "3.13"


### PR DESCRIPTION
Fixes #7

A clean install can't start, because two dependencies aren't declared.

**`psutil`** — `dist/app/server.py` imports it at line 7 and calls `psutil.Process()` at line 134, but it isn't in `requirements.txt`, so the first launch ends in `ModuleNotFoundError: No module named 'psutil'`.

**`audioop-lts` on Python 3.13+** — `pydub` imports the stdlib `audioop` module, which PEP 594 removed in 3.13. Its fallback is `import pyaudioop`, which doesn't exist on PyPI — that's why @Stoltverd got `No matching distribution found for pyaudioop` when trying to install the name from the traceback. `audioop-lts` is the maintained replacement.

One detail worth flagging: `audioop-lts` declares `Requires-Python >=3.13`, so adding it unconditionally breaks installs on 3.10–3.12. I gated it behind an environment marker:

```
audioop-lts; python_version >= "3.13"
```

### What I checked

Built two throwaway virtualenvs on macOS 15 (Apple Silicon):

- **Python 3.13, before the fix** — `from pydub import AudioSegment` fails with `ModuleNotFoundError: No module named 'pyaudioop'`, matching the report in this thread.
- **Python 3.13, after the fix** — `pydub` and `psutil` both import; `audioop` resolves to the `audioop-lts` package.
- **Python 3.12** — confirmed `audioop` is still in the stdlib there, and that `pip install audioop-lts` is refused with `Requires-Python >=3.13`, which is what the marker is for.

I reproduced this on macOS, not Windows 11 — but the failing import is platform-independent, and it matches what three people reported here.
