### PR TITLE
Use platform-native FFmpeg instead of assuming a Windows build

### DIFF
--- a/dist/app/logic/dependency_manager.py
+++ b/dist/app/logic/dependency_manager.py
@@ -19,10 +19,15 @@ else:
     BASE_DIR = Path(__file__).parent.parent.parent
 
 BIN_DIR = BASE_DIR / "bin"
-FFMPEG_EXE = BIN_DIR / "ffmpeg.exe"
-FFPROBE_EXE = BIN_DIR / "ffprobe.exe"
 
-# Stable FFMPEG build from Gyan.dev
+# Only Windows binaries carry a .exe suffix. Keep these constant names -- other
+# modules import them -- but resolve the filename per platform.
+IS_WINDOWS = sys.platform == "win32"
+_SUFFIX = ".exe" if IS_WINDOWS else ""
+FFMPEG_EXE = BIN_DIR / f"ffmpeg{_SUFFIX}"
+FFPROBE_EXE = BIN_DIR / f"ffprobe{_SUFFIX}"
+
+# Stable FFMPEG build from Gyan.dev. Windows-only build -- see install().
 FFMPEG_DOWNLOAD_URL = "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip"
 
 class FFMPEGInstaller:
@@ -37,8 +42,8 @@ class FFMPEGInstaller:
         self.is_cancelled = False
     
     def check_installed(self) -> bool:
-        """Check if FFMPEG binaries are already installed"""
-        return FFMPEG_EXE.exists() and FFPROBE_EXE.exists()
+        """True if usable ffmpeg AND ffprobe exist, bundled in bin/ or on PATH."""
+        return bool(get_ffmpeg_path() and get_ffprobe_path())
     
     def cancel(self):
         """Cancel the download process"""
@@ -51,6 +56,17 @@ class FFMPEGInstaller:
         Returns:
             (success: bool, error_message: Optional[str])
         """
+        # FFMPEG_DOWNLOAD_URL is a Windows build: unpacking it on macOS/Linux
+        # yields .exe files that cannot run. Use the platform's own ffmpeg there.
+        if not IS_WINDOWS:
+            if self.check_installed():
+                self._update_progress(1, 1, "Using system FFMPEG")
+                return True, None
+            return False, (
+                "FFmpeg was not found on this system. Install it and restart, e.g. "
+                "'brew install ffmpeg' on macOS or your package manager on Linux."
+            )
+
         try:
             # 1. Create bin directory
             BIN_DIR.mkdir(exist_ok=True)
@@ -126,23 +142,23 @@ class FFMPEGInstaller:
             except Exception as e:
                 print(f"Progress callback error: {e}")
 
+def _resolve(bundled: Path, name: str) -> Optional[str]:
+    """
+    Prefer the copy in bin/, then fall back to whatever is on PATH so a
+    system-managed install (Homebrew, apt, winget) works without downloading.
+    Returns None if neither exists.
+    """
+    if bundled.exists():
+        return str(bundled)
+    return shutil.which(name)
+
 def get_ffmpeg_path() -> Optional[str]:
-    """
-    Get the path to the local FFMPEG executable.
-    Returns None if not installed.
-    """
-    if FFMPEG_EXE.exists():
-        return str(FFMPEG_EXE)
-    return None
+    """Path to a usable ffmpeg, or None if not installed."""
+    return _resolve(FFMPEG_EXE, "ffmpeg")
 
 def get_ffprobe_path() -> Optional[str]:
-    """
-    Get the path to the local FFPROBE executable.
-    Returns None if not installed.
-    """
-    if FFPROBE_EXE.exists():
-        return str(FFPROBE_EXE)
-    return None
+    """Path to a usable ffprobe, or None if not installed."""
+    return _resolve(FFPROBE_EXE, "ffprobe")
 
 # Configure pydub to use local FFMPEG
 def configure_pydub():

--- a/dist/app/server.py
+++ b/dist/app/server.py
@@ -44,8 +44,26 @@ async def lifespan(app: FastAPI):
     )
     safe_init_json(library_file, [])
 
-    # 3. Check/Install FFMPEG (Async check could go here)
-    # We leave that for the frontend to query via /api/ffmpeg/status
+    # 3. Detect FFMPEG once at startup. ffmpeg_status defaults to
+    # is_installed=False and used to be flipped only by the installer, so an
+    # already-present ffmpeg (bundled in bin/ or system-managed) was reported
+    # missing and the UI kept offering a download it did not need.
+    try:
+        from .logic.dependency_manager import (
+            FFMPEGInstaller,
+            configure_pydub,
+            get_ffmpeg_path,
+        )
+
+        if FFMPEGInstaller().check_installed():
+            configure_pydub()
+            state_module.ffmpeg_status["is_installed"] = True
+            state_module.ffmpeg_status["message"] = "Ready"
+            print(f"[OK] FFMPEG found: {get_ffmpeg_path()}")
+        else:
+            print("[INFO] FFMPEG not found; MP3 export unavailable until installed.")
+    except Exception as e:
+        print(f"[WARNING] FFMPEG detection failed: {e}")
 
     # 4. Clean temp content
     try:

--- a/dist/main.py
+++ b/dist/main.py
@@ -13,7 +13,8 @@ base_dir = Path(__file__).parent.absolute()
 sys.path.insert(0, str(base_dir))
 
 # --- 2. LOCAL FFMPEG SETUP ---
-# Point system PATH to our local /bin folder so pydub finds ffmpeg.exe
+# Point system PATH at our local /bin folder first, so a bundled ffmpeg wins
+# over any system copy. Only Windows ships binaries here.
 bin_path = base_dir / "bin"
 
 if bin_path.exists():
@@ -21,8 +22,10 @@ if bin_path.exists():
     os.environ["PATH"] = str(bin_path) + os.pathsep + os.environ["PATH"]
     print(f"[OK] Local FFMPEG linked: {bin_path}")
 else:
-    print(f"[WARNING] Local 'bin' folder not found at {bin_path}")
-    print(f"          FFMPEG will need to be downloaded on first export.")
+    # A missing bin/ only matters when nothing else supplies ffmpeg. On
+    # macOS/Linux it normally comes from the system package manager, so don't
+    # warn about a download that isn't needed -- server.py reports what it found.
+    print(f"[INFO] No local 'bin' folder; will use system FFMPEG if available.")
 
 # --- 3. IMPORT APP ---
 # Now when pydub loads, it will find our local ffmpeg first


### PR DESCRIPTION
The README lists Linux under installation and Ubuntu 20.04+ under supported systems, but the FFmpeg integration assumes Windows throughout, so MP3 export can't work outside it:

- `dependency_manager.py` hardcodes the binary paths to `ffmpeg.exe` / `ffprobe.exe`
- `install()` downloads the gyan.dev build, which is Windows-only — on macOS or Linux it unpacks `.exe` files that can't run
- nothing consults `PATH`, so a system-managed ffmpeg (Homebrew, apt) is ignored even when it's right there

### Changes

- Resolve `ffmpeg`/`ffprobe` per platform — `.exe` suffix only on Windows
- Fall back to `shutil.which()` so a system-managed install is used if `bin/` is empty
- Short-circuit `install()` on non-Windows: use the system copy if present, otherwise return a message pointing at the package manager rather than downloading binaries that can't run

### Also fixes a Windows bug

`ffmpeg_status["is_installed"]` defaulted to `False` and was only ever flipped by the installer. Nothing checked at startup, so an FFmpeg that was already present — **including a bundled `bin/ffmpeg.exe` on Windows** — was reported missing, and the UI kept offering a download that wasn't needed. It's now detected once during startup and `configure_pydub()` is called at the same point.

### What I checked

On macOS 15 (Apple Silicon), with ffmpeg from Homebrew:

- Startup logs `[OK] FFMPEG found: /opt/homebrew/bin/ffmpeg`
- `/api/ffmpeg/status` returns `is_installed: true` with message `Ready` — before this change it returned `false` with ffmpeg installed and working
- Exported a real MP3 through `configure_pydub()` + `AudioSegment.export()`

I haven't tested this on Windows or Linux. The Windows path is unchanged in behavior apart from the startup detection, but it would be worth a check on a Windows box before merging, particularly that `bin/ffmpeg.exe` is still found first when present.

Happy to adjust anything here — including splitting the startup-detection fix into its own PR if you'd rather keep them separate.
