### PR TITLE
Serialize TTS synthesis: espeak-ng is not thread-safe

### DIFF
--- a/dist/app/routers/export.py
+++ b/dist/app/routers/export.py
@@ -186,12 +186,13 @@ async def export_audio(request: ExportRequest, background_tasks: BackgroundTasks
                     lang = get_language_from_voice(request.voice)
 
                     # Use state_module.kokoro
-                    samples, sample_rate = state_module.kokoro.create(
-                        processed_text,
-                        voice=request.voice,
-                        speed=float(request.speed),
-                        lang=lang,
-                    )
+                    with state_module.engine_lock:
+                        samples, sample_rate = state_module.kokoro.create(
+                            processed_text,
+                            voice=request.voice,
+                            speed=float(request.speed),
+                            lang=lang,
+                        )
 
                     buffer = io.BytesIO()
                     sf.write(

--- a/dist/app/routers/tts.py
+++ b/dist/app/routers/tts.py
@@ -156,25 +156,23 @@ def synthesize_with_pauses(
     audio_map = {}
 
     if tts_tasks and state_module.kokoro:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
-            future_to_idx = {
-                executor.submit(
-                    state_module.kokoro.create,
-                    t["text"],
-                    voice=voice,
-                    speed=speed,
-                    lang=lang,
-                ): t["index"]
-                for t in tts_tasks
-            }
-            for future in concurrent.futures.as_completed(future_to_idx):
-                idx = future_to_idx[future]
-                try:
-                    samples, _ = future.result()
-                    audio_map[idx] = samples.flatten()
-                except Exception as e:
-                    print(f"Segment {idx} failed: {e}")
-                    audio_map[idx] = None
+        # Synthesized one at a time on purpose. This previously ran on a
+        # ThreadPoolExecutor(max_workers=4), but espeak-ng phonemization is not
+        # thread-safe (see state.engine_lock), so the chunks came back holding
+        # each other's words and the assembled sentence was scrambled. The
+        # executor also never bought much: onnxruntime already parallelizes a
+        # single inference across cores.
+        for t in tts_tasks:
+            idx = t["index"]
+            try:
+                with state_module.engine_lock:
+                    samples, _ = state_module.kokoro.create(
+                        t["text"], voice=voice, speed=speed, lang=lang
+                    )
+                audio_map[idx] = samples.flatten()
+            except Exception as e:
+                print(f"Segment {idx} failed: {e}")
+                audio_map[idx] = None
 
     final_segments = []
     for item in plan:
@@ -359,22 +357,24 @@ async def synthesize(request: SynthesisRequest):
                 # GemGem-style pre-chunking for direct synthesis path
                 sub_chunks = graceful_chunk_for_tts(text)
                 if len(sub_chunks) == 1:
-                    samples, sample_rate = state_module.kokoro.create(
-                        text,
-                        voice=selected_voice,
-                        speed=float(request.speed or 1.0),
-                        lang=lang,
-                    )
-                else:
-                    chunk_audios = []
-                    sample_rate = SAMPLE_RATE
-                    for chunk in sub_chunks:
-                        chunk_samples, sr = state_module.kokoro.create(
-                            chunk,
+                    with state_module.engine_lock:
+                        samples, sample_rate = state_module.kokoro.create(
+                            text,
                             voice=selected_voice,
                             speed=float(request.speed or 1.0),
                             lang=lang,
                         )
+                else:
+                    chunk_audios = []
+                    sample_rate = SAMPLE_RATE
+                    for chunk in sub_chunks:
+                        with state_module.engine_lock:
+                            chunk_samples, sr = state_module.kokoro.create(
+                                chunk,
+                                voice=selected_voice,
+                                speed=float(request.speed or 1.0),
+                                lang=lang,
+                            )
                         chunk_audios.append(chunk_samples.flatten())
                         sample_rate = sr
                     samples = safe_concat(chunk_audios)

--- a/dist/app/state.py
+++ b/dist/app/state.py
@@ -18,6 +18,14 @@ except ImportError:
 audio_cache = AudioCache(cache_db_path, max_size_mb=MAX_CACHE_SIZE_MB)
 kokoro = None  # The TTS engine instance
 
+# Serializes every call into the TTS engine.
+#
+# Kokoro phonemizes through espeak-ng, which keeps global state behind a single
+# shared library handle (phonemizer holds it in a class attribute) and is not
+# thread-safe. Calling create() from more than one thread interleaves text
+# through that state and returns phonemes belonging to other calls.
+engine_lock = threading.Lock()
+
 system_status = {"is_loading": False, "last_error": None, "is_downloading": False}
 
 export_status = {


### PR DESCRIPTION
`synthesize_with_pauses` splits a sentence at its punctuation and synthesizes the pieces on a `ThreadPoolExecutor(max_workers=4)`. Kokoro phonemizes through espeak-ng, which keeps global state behind a single shared library handle — `phonemizer` stores it in a class attribute — so concurrent calls interleave text through that state and return phonemes belonging to other calls.

### Reproducing it

Using the sentence *"I began to serve my sentence of detention in the Fortress of Landsberg am Lech, following the verdict pronounced by the Munich people's court on that day."*, calling `tokenizer.phonemize` from 4 threads:

```
corrupted results: 31 / 32

expected: aɪ bɪɡˈæn tə sˈɜːv maɪ sˈɛntəns ʌv dɪtˈɛnʃən ɪnðə fˈɔːɹtɹəs ʌv lˈændsbɜːɡ ɐm lˈɛtʃ
got     : fˈɔːɹtɹəs ʌv lˈændsbɜːɡ ɐm lˈɛtʃ  fˈɑːloʊ
```

That trailing `fˈɑːloʊ` is *"following"* — the first word of the **other** chunk, leaked across threads mid-call.

Through the app's own path, the same input produced five different outputs in five runs:

```
run 0: 12.97s  sha=ef4abecb0d517f7e
run 1:  9.28s  sha=3205e208ce2d8a57
run 2:  7.21s  sha=f742416a7a003017
run 3: 11.74s  sha=5ae0d9a5ffe0474c
run 4: 11.23s  sha=e59207bd9e2316d1
distinct outputs for identical input: 5
```

Audibly the two halves of the sentence are spliced together word-group by word-group: *"Following the / I / verdict / begin to serve my / pronounced by the Munich / sentence of / people's / detention in the / court on that day."*

### The change

Replaced the executor with a serial loop, and added `state.engine_lock` around every `create()` call — including the MP3 export path, which runs in a worker thread and can otherwise collide with playback.

### After

```
run 0..4: 9.28s  sha=3205e208ce2d8a57   (all five identical)
distinct outputs: 1
chunk A found at sample 0 (correlation 1.000), chunk B after it — correct order
```

The executor wasn't buying much anyway: onnxruntime already parallelizes a single inference across cores. Measured cost is ~2.05x realtime versus ~2.26x before, on an Apple Silicon Mac.

### What I checked, and what I didn't

Measured on macOS 15 (Apple Silicon), Python 3.12, with the quantized `kokoro.int8.onnx` model. I have not run this on Windows or Linux — but the thread-safety issue is in espeak-ng and phonemizer, not in anything platform-specific, so I would expect the same behaviour anywhere the executor runs more than one worker.

I noticed this because the audio in my own reading was scrambled; it may be worth checking whether it relates to #8, since pause settings route through exactly this function. I haven't verified that link.
