### PR TITLE
Stop replaced audio sources from running the sentence-ended path

### DIFF
--- a/dist/app/ui/js/modules/tts.js
+++ b/dist/app/ui/js/modules/tts.js
@@ -18,6 +18,13 @@ export function initAudioContext() {
 export function playAudioBuffer(audioBuffer) {
   if (state.currentAudioSource) {
     try {
+      // Detach onended BEFORE stop(). stop() fires the ended event, so leaving
+      // the handler attached makes the outgoing source run the "sentence
+      // finished" path on its way out: currentSentenceIndex++ and another
+      // playNext(). That starts a second playback racing the one being started
+      // here, and skips a sentence via the extra increment. stopPlayback() and
+      // jumpToSentence() already do this.
+      state.currentAudioSource.onended = null;
       state.currentAudioSource.stop();
       state.currentAudioSource.disconnect();
     } catch (e) {}
@@ -60,7 +67,15 @@ export function stopPlayback() {
   }
 }
 
+// Incremented on every playNext() entry. Each call keeps its own token and must
+// still hold the newest one to start audio. The sentence-index check alone is
+// not enough: two calls can share a target index (a natural ended event landing
+// at the same moment as a jump timer) and both pass it, so both start playback
+// and the sentences are heard on top of each other.
+let playToken = 0;
+
 export async function playNext() {
+  const myToken = ++playToken;
   const targetIndex = state.currentSentenceIndex;
   if (!state.isPlaying || !window.isEngineReady) {
     // isEngineReady is global/window for now
@@ -123,6 +138,12 @@ export async function playNext() {
   const lookupKey = `${state.readingPageIndex}_${targetIndex}_${voiceSelect.value}_${speedRange.value}`;
 
   if (state.audioBufferCache.has(lookupKey)) {
+    // The page-advance branch above awaits, so even this path can be reached
+    // after a newer call has taken over.
+    if (myToken !== playToken) {
+      console.log(`[TTS] Discarding cache hit - superseded`);
+      return;
+    }
     console.log(`[WebAudio] CACHE HIT - Playing cached buffer instantly`);
     playAudioBuffer(state.audioBufferCache.get(lookupKey));
     return;
@@ -166,6 +187,21 @@ export async function playNext() {
     if (state.audioBufferCache.size > state.MAX_AUDIO_CACHE) {
       const firstKey = state.audioBufferCache.keys().next().value;
       state.audioBufferCache.delete(firstKey);
+    }
+
+    // decodeAudioData is async, so the check above can pass and the state can
+    // still move on before we get here -- a page turn or a click on another
+    // sentence lands in that window. Caching above is deliberately kept: the
+    // work is done and stays useful on the way back.
+    if (
+      !state.isPlaying ||
+      state.currentSentenceIndex !== targetIndex ||
+      myToken !== playToken
+    ) {
+      console.log(
+        `[TTS] Discarding decoded audio - superseded (index ${state.currentSentenceIndex} vs ${targetIndex})`,
+      );
+      return;
     }
 
     playAudioBuffer(audioBuffer);


### PR DESCRIPTION
`playAudioBuffer()` stops the outgoing source without detaching its handler first:

```js
if (state.currentAudioSource) {
  state.currentAudioSource.stop();       // fires onended
  state.currentAudioSource.disconnect();
}
```

`stop()` fires the ended event, so the outgoing sentence runs the "finished" path on its way out — `currentSentenceIndex++` and another `playNext()`. That starts a second playback racing the one being set up here, and skips a sentence via the extra increment.

`stopPlayback()` already guards against exactly this, with a comment saying so:

```js
state.currentAudioSource.onended = null; // Prevent triggering 'playNext' on stop
```

`jumpToSentence()` does the same. `playAudioBuffer()` was the one place that didn't.

### Two further races in `playNext()`

- The staleness check runs *before* `await decodeAudioData(...)`, but playback happens *after* it. A result that was current when checked can still start playing after the reader has moved on. Re-checked after the decode.
- Two calls can share a target index — a natural ended event landing at the same moment as a jump timer — and both pass the index check, so both start audio. Added a `playToken` that increments per call; only the newest holder may start playback. Enforced at all playback points, including the cache-hit path, which is reachable after an await via the page-advance branch.

### What I checked

Drove the UI in Chrome with `AudioBufferSourceNode.start/stop` and the ended event hooked, so every source's lifetime was recorded:

- 45s of plain playback: **0 overlapping sources**, sentences in order, seamless gaps
- 30 actions (sentence clicks, skips, page turns, speed changes): **0 overlapping sources**, 8 races caught and discarded by the guards, and **no `stop()` observed with a handler still attached**

Verified on macOS 15 (Apple Silicon) in Chrome and in the pywebview window. Not tested on Windows or Linux, though nothing here is platform-specific.
